### PR TITLE
remove bare variable use

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,4 +49,4 @@
   apt:
     pkg: "{{item}}"
     state: present
-  with_items: apt_default_packages
+  with_items: "{{apt_default_packages}}"


### PR DESCRIPTION
cleanup bare variable usage to get rid of depreciation warnings on Ansible >= 2
